### PR TITLE
[RFR-270] Use same gradle.properties everywhere

### DIFF
--- a/gradle.properties.template
+++ b/gradle.properties.template
@@ -9,7 +9,7 @@
 
 # Specifies the JVM arguments used for the daemon process.
 # The setting is particularly useful for tweaking memory settings.
-org.gradle.jvmargs=-Xmx1536m
+org.gradle.jvmargs=-Xmx2048m -Dfile.encoding=UTF-8
 
 # When configured, Gradle will run in incubating parallel mode.
 # This option should only be used with decoupled projects. More details, visit
@@ -21,7 +21,15 @@ org.gradle.jvmargs=-Xmx1536m
 # https://developer.android.com/topic/libraries/support-library/androidx-rn
 android.useAndroidX=true
 
-# Automatically convert third-party libraries to use AndroidX
+# Kotlin code style for this project: "official" or "obsolete":
+kotlin.code.style=official
+
+# Enables namespacing of each library's R class so that its R class includes only the
+# resources declared in the library itself and none from the library's dependencies,
+# thereby reducing the size of the R class for that library
+android.nonTransitiveRClass=true
+
+android.builder.sdkDownload=true
 android.enableJetifier=true
 
 # Secrets


### PR DESCRIPTION
When generating a new Android Project, I noticed that the default settings changed.
One of those settings is `nonTransitiveRClass` which speeds up the build time.

Thus, I'm porting these new settings to all Android projects.